### PR TITLE
refactor: 프로필, auth, 태그 기능 수정

### DIFF
--- a/front/src/features/event/_apis/attendee.api.ts
+++ b/front/src/features/event/_apis/attendee.api.ts
@@ -3,17 +3,6 @@ import type { PatchAttendeeStatusBody } from "../_types/body";
 import type { GetEventsAttendeesResponse } from "../_types/response";
 import type { MutationResponse } from "@/shared/types/api";
 
-// /**
-//  *@description events 일정 참석자 목록 api
-// TODO 회의 후, 결정
-//  */
-// export const getEventAttendeeAllStatusApi = (eventId: number) => {
-//   return apiCall<undefined>({
-//     url: `/events/${eventId}/attendees`,
-//     method: "GET",
-//   });
-// };
-
 /**
  *@description attendees 참석자 목록 조회 api (참석자 + 대기자)
  */

--- a/front/src/features/event/_components/attendee/EventAttendeesModal.tsx
+++ b/front/src/features/event/_components/attendee/EventAttendeesModal.tsx
@@ -1,11 +1,7 @@
-import { useState } from "react";
 import styles from "./EventAttendeesModal.module.scss";
-import { patchAttendeeStatusApi } from "../../_apis/attendee.api";
 import type { PatchAttendeeStatusBody } from "../../_types/body";
-import type { GetEventsAttendeesResponse } from "../../_types/response";
 import { useGetEventAttendeeApi } from "../../_hooks/attendee/query";
 import { usePatchAttendeeStatusApi } from "../../_hooks/attendee/mutation";
-import { fi } from "zod/locales";
 import { isAxiosError } from "axios";
 import { useUiStore } from "@/shared/stores/ui.store";
 
@@ -19,7 +15,7 @@ type Props = {
 /**
  *@description event(일정) 참석자 관리 모달
  */
-export function EventAttendeesModal({ isOpen, onClose, eventId }: Props) {
+export function EventAttendeesModal({ isOpen, onClose, eventId, isAdmin }: Props) {
   if (!isOpen || !eventId) return null;
 
   const role = {
@@ -56,6 +52,7 @@ export function EventAttendeesModal({ isOpen, onClose, eventId }: Props) {
       }
     }
   };
+
   return (
     <div className={styles.overlay}>
       <div className={styles.modal}>
@@ -98,12 +95,16 @@ export function EventAttendeesModal({ isOpen, onClose, eventId }: Props) {
                   <span className={styles.role}>{role[attendee.role]}</span>
                 </div>
 
-                <div className={styles.actions}>
-                  <button onClick={() => onManageAttendance(attendee.userId, "GOING")}>승인</button>
-                  <button onClick={() => onManageAttendance(attendee.userId, "CANCELLED")}>
-                    취소
-                  </button>
-                </div>
+                {isAdmin && (
+                  <div className={styles.actions}>
+                    <button onClick={() => onManageAttendance(attendee.userId, "GOING")}>
+                      승인
+                    </button>
+                    <button onClick={() => onManageAttendance(attendee.userId, "CANCELLED")}>
+                      취소
+                    </button>
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/front/src/features/event/_components/attendee/EventAttendeesModal.tsx
+++ b/front/src/features/event/_components/attendee/EventAttendeesModal.tsx
@@ -4,6 +4,7 @@ import { useGetEventAttendeeApi } from "../../_hooks/attendee/query";
 import { usePatchAttendeeStatusApi } from "../../_hooks/attendee/mutation";
 import { isAxiosError } from "axios";
 import { useUiStore } from "@/shared/stores/ui.store";
+import { useUserId } from "@/features/users/_hooks/useUserId";
 
 type Props = {
   isOpen: boolean;
@@ -17,6 +18,8 @@ type Props = {
  */
 export function EventAttendeesModal({ isOpen, onClose, eventId, isAdmin }: Props) {
   if (!isOpen || !eventId) return null;
+
+  const userId = useUserId();
 
   const role = {
     HOST: "모임장",
@@ -72,7 +75,7 @@ export function EventAttendeesModal({ isOpen, onClose, eventId, isAdmin }: Props
                   <span className={styles.role}>{role[attendee.role]}</span>
                 </div>
 
-                {attendee.role === "ATTENDEE" && (
+                {attendee.role === "ATTENDEE" && userId === attendee.userId && (
                   <div className={styles.actions}>
                     <button onClick={() => onManageAttendance(attendee.userId, "CANCELLED")}>
                       취소

--- a/front/src/features/group/_apis/group.api.ts
+++ b/front/src/features/group/_apis/group.api.ts
@@ -37,7 +37,7 @@ export const patchGroupsApi = (body: PatchGroupsBody, groupId?: string) => {
  */
 export const getGroupsListApi = (params: GetGroupsListQuery) => {
   return apiCall<GetGroupsListResponse>({
-    url: "/groups/search",
+    url: "/groups",
     params,
   });
 };

--- a/front/src/features/group/_components/GroupSearchItem.tsx
+++ b/front/src/features/group/_components/GroupSearchItem.tsx
@@ -9,6 +9,7 @@ import LikeButton from "@/shared/components/button/LikeButton";
 import { usePostGroupsLike } from "../_hooks/mutation";
 import { useUiStore } from "@/shared/stores/ui.store";
 import { isAxiosError } from "axios";
+import { getImageUrl } from "@/libs/image";
 
 type Props = {
   data: GroupsItem;
@@ -68,17 +69,10 @@ export function GroupSearchItem({ data, refetch }: Props) {
       onKeyDown={onKeyDownGroup}
     >
       {/* 이미지 */}
-      {!imageError && data.imageUrl && (
-        <img
-          src={`${import.meta.env.VITE_APP_IMG_BASE_URL}${data.imageUrl}`}
-          alt={data.name}
-          className={styles.image}
-          onError={() => {
-            setImageError(true);
-          }}
-        />
+      {data.imageUrl && (
+        <img src={`${getImageUrl(data.imageUrl)}`} alt={data.name} className={styles.image} />
       )}
-      {(imageError || !data.imageUrl) && (
+      {!data.imageUrl && (
         <img src={"https://placehold.co/300x200"} alt={"대체 이미지"} className={styles.image} />
       )}
 

--- a/front/src/features/group/_components/info/content/GroupInfoContent.tsx
+++ b/front/src/features/group/_components/info/content/GroupInfoContent.tsx
@@ -129,8 +129,8 @@ function GroupInfoContent({ data, refetchGroupsOne }: Props) {
 
       {/* 태그 */}
       <div className={styles.tags_view}>
-        {data.tags.split(",").map((tag) => (
-          <Tag name={tag} />
+        {data.tags.split(",").map((tag, i) => (
+          <Tag name={tag} key={`${tag}_${i}`} />
         ))}
       </div>
 

--- a/front/src/features/group/_components/info/content/GroupInfoContent.tsx
+++ b/front/src/features/group/_components/info/content/GroupInfoContent.tsx
@@ -2,7 +2,11 @@ import Tag from "@/shared/components/tag/Tag";
 import styles from "./GroupInfoContent.module.scss";
 import type { GroupsItem } from "@/features/group/_types/base";
 import LikeButton from "@/shared/components/button/LikeButton";
-import { useDeleteGroupsLeaveApi, usePostGroupsJoinApi } from "@/features/group/_hooks/mutation";
+import {
+  useDeleteGroupsLeaveApi,
+  usePostGroupsJoinApi,
+  usePostGroupsLike,
+} from "@/features/group/_hooks/mutation";
 import { useUiStore } from "@/shared/stores/ui.store";
 import type { ErrorResponse } from "react-router-dom";
 import { isAxiosError } from "axios";
@@ -18,6 +22,7 @@ type Props = {
 function GroupInfoContent({ data, refetchGroupsOne }: Props) {
   const { mutateAsync: mutateJoin } = usePostGroupsJoinApi();
   const { mutateAsync: mutateLeave } = useDeleteGroupsLeaveApi();
+  const { mutateAsync: mutateLike } = usePostGroupsLike();
   const { showToast } = useUiStore();
 
   // 모임 가입 이벤트
@@ -73,6 +78,29 @@ function GroupInfoContent({ data, refetchGroupsOne }: Props) {
     }
   };
 
+  // 좋아요 클릭
+  const onHeartTogggle = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.stopPropagation();
+
+    mutateLike(data.id)
+      .then((res) => {
+        if (res.status === 200) {
+          refetchGroupsOne();
+          showToast({
+            message: res.data.liked ? "찜했습니다." : "찜 해제했습니다.",
+            type: "success",
+          });
+        }
+      })
+      .catch((error) => {
+        if (isAxiosError(error)) {
+          if (error.status === 403) {
+            showToast({ message: "접근 권한이없습니다.", type: "error" });
+          }
+        }
+      });
+  };
+
   return (
     <section className={styles.group_content}>
       {/* 모임 이름 + 탈퇴 버튼 */}
@@ -80,7 +108,9 @@ function GroupInfoContent({ data, refetchGroupsOne }: Props) {
         <div className={styles.top_view_left}>
           <h2>{data.name}</h2>
 
-          <LikeButton isLike={data.liked} />
+          <button onClick={onHeartTogggle}>
+            <LikeButton isLike={data.liked} />
+          </button>
         </div>
 
         <button onClick={data?.joined ? onLeave : onJoin}>

--- a/front/src/features/group/_components/info/memberList/MemberItem.module.scss
+++ b/front/src/features/group/_components/info/memberList/MemberItem.module.scss
@@ -10,7 +10,15 @@
     width: 44px;
     height: 44px;
     border-radius: 100%;
-    background-color: #111;
+    background-color: $color-grayscale-60;
+    border: 1px solid $color-grayscale-20;
+  }
+
+  .no_profile_image {
+    width: 44px;
+    height: 44px;
+    border-radius: 100%;
+    background-color: $color-grayscale-10;
     border: 1px solid $color-grayscale-20;
   }
 

--- a/front/src/features/group/_components/info/memberList/MemberItem.tsx
+++ b/front/src/features/group/_components/info/memberList/MemberItem.tsx
@@ -16,7 +16,9 @@ type Props = {
 function MemberItem({ name, description, onKick, onDelegate, userId, imageUrl }: Props) {
   return (
     <div className={styles.member_wrapper}>
-      <img alt={"member_image"} src={getImageUrl(imageUrl)} />
+      {imageUrl && <img alt={"member_image"} src={getImageUrl(imageUrl)} />}
+
+      {!imageUrl && <div className={styles.no_profile_image} />}
 
       <div className={styles.member_info}>
         <p>{name}</p>

--- a/front/src/features/group/_hooks/query.ts
+++ b/front/src/features/group/_hooks/query.ts
@@ -44,7 +44,7 @@ export function useGetMyJoinedGroupsApi(params: PagingQuery) {
     queryKey: [reactQueryKeys.group.getMyJoinedGroup, params],
     queryFn: () => getMyJoinedGroupsApi(params),
     select: (data) => {
-      return data.data.reverse();
+      return data.data;
     },
   });
 }

--- a/front/src/pages/group/info/GroupInfoPage.tsx
+++ b/front/src/pages/group/info/GroupInfoPage.tsx
@@ -32,6 +32,7 @@ function GroupInfoPage() {
 
   const [isEventMoreOpen, setEventMoreOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<number>();
+  const [isEventShowList, setEventShowList] = useState(false);
   const { showToast } = useUiStore();
 
   const userId = useUserId();
@@ -59,13 +60,23 @@ function GroupInfoPage() {
   // 탭 활성화 이벤트, state
   const { onChangeTab, activeKey } = useSetGroupTab();
 
-  // 그룹 상세정보 state
-
   // 그룹 멤버 state
   const { data: groupMembers } = useGetGroupMemberApi(groupId);
 
   const { mutateAsync: mutateAttend } = usePostEventsAttendeeApi();
   const { mutateAsync: mutateDelete } = useDeleteCancelEventAttendeeApi();
+
+  // close view list
+  const onCloseViewList = () => {
+    setEventShowList(false);
+    setSelectedEvent(undefined);
+  };
+
+  // show view list
+  const onShowViewList = () => {
+    setEventShowList(true);
+    setEventMoreOpen(false);
+  };
 
   // 탈퇴
   const onWithdrawl = (eventId?: number) => {
@@ -200,17 +211,18 @@ function GroupInfoPage() {
         open={isEventMoreOpen}
         firstText={isOwner ? "수정" : "참여"}
         secondText={!isOwner ? "취소" : undefined}
+        thirdText={"보기"}
         onClickFirst={() => onAttendAndModify(selectedEvent)}
         onClickSecond={() => onWithdrawl(selectedEvent)}
+        onClickThird={onShowViewList}
         onClose={() => setEventMoreOpen(false)}
         destructive="second"
       />
 
       <EventAttendeesModal
-        isOpen={false}
-        onClose={function (): void {
-          throw new Error("Function not implemented.");
-        }}
+        isOpen={isEventShowList}
+        onClose={onCloseViewList}
+        eventId={selectedEvent}
       />
     </CommonLayout>
   );

--- a/front/src/pages/group/info/GroupInfoPage.tsx
+++ b/front/src/pages/group/info/GroupInfoPage.tsx
@@ -12,7 +12,7 @@ import useSetGroupTab from "@/features/group/_hooks/useSetGroupTab";
 import { useGetGroupMemberApi, useGetGroupsOneApi } from "@/features/group/_hooks/query";
 import { useGetEventsListApi } from "@/features/event/_hooks/event/query";
 import ActionSheet from "@/shared/components/actionsheet/ActionSheet";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   useDeleteCancelEventAttendeeApi,
   usePostEventsAttendeeApi,
@@ -21,6 +21,7 @@ import { useUiStore } from "@/shared/stores/ui.store";
 import { isAxiosError } from "axios";
 import { useUserId } from "@/features/users/_hooks/useUserId";
 import useLoading from "@/shared/hooks/useLoading";
+import { EventAttendeesModal } from "@/features/event/_components/attendee/EventAttendeesModal";
 
 /**
  *@description 내 모임 탭 > 모임 정보 페이지
@@ -32,6 +33,7 @@ function GroupInfoPage() {
   const [isEventMoreOpen, setEventMoreOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<number>();
   const { showToast } = useUiStore();
+
   const userId = useUserId();
 
   const { data, refetch: refetchGroupsOne, isLoading } = useGetGroupsOneApi(groupId);
@@ -52,7 +54,7 @@ function GroupInfoPage() {
       ];
 
   // 이벤트(일정) 목록 state
-  const { data: eventsList } = useGetEventsListApi(groupId);
+  const { data: eventsList, refetch: refetchEvents } = useGetEventsListApi(groupId);
 
   // 탭 활성화 이벤트, state
   const { onChangeTab, activeKey } = useSetGroupTab();
@@ -82,6 +84,7 @@ function GroupInfoPage() {
             message: "일정에 나갔습니다.",
             type: "success",
           });
+          refetchEvents();
         }
       })
       .catch((error) => {
@@ -127,6 +130,7 @@ function GroupInfoPage() {
             message: "일정에 참석되었습니다.",
             type: "success",
           });
+          refetchEvents();
         }
       })
       .catch((error) => {
@@ -200,6 +204,13 @@ function GroupInfoPage() {
         onClickSecond={() => onWithdrawl(selectedEvent)}
         onClose={() => setEventMoreOpen(false)}
         destructive="second"
+      />
+
+      <EventAttendeesModal
+        isOpen={false}
+        onClose={function (): void {
+          throw new Error("Function not implemented.");
+        }}
       />
     </CommonLayout>
   );

--- a/front/src/pages/group/register/GroupRegisterPage.tsx
+++ b/front/src/pages/group/register/GroupRegisterPage.tsx
@@ -82,16 +82,19 @@ function GroupRegisterPage() {
   const [tags, setTags] = useState<string[]>([]);
   const [tag, setTag] = useState("");
 
+  const [isComposing, setIsComposing] = useState(false);
+
   // 태그 추가
   const onAddTag = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && tag.trim()) {
+    if (e.key === "Enter" && !isComposing) {
       e.preventDefault();
+      const value = tag.trim();
+      if (!value) return;
       if (tags.length >= 3) {
         return showToast({ message: "태그는 최대 3개까지 가능합니다.", type: "error" });
       }
-      if (tags.includes(tag.trim())) return;
-
-      setTags((prev) => [...prev, tag.trim()]);
+      if (tags.includes(value)) return;
+      setTags((prev) => [...prev, value]);
       setTag("");
     }
   };
@@ -240,11 +243,13 @@ function GroupRegisterPage() {
         <Card title="부가 정보">
           <InputField
             value={tag}
+            onChange={(e) => setTag(e.target.value)}
             label={"모임에 관련된 태그를 추가해주세요. (최대 3개)"}
             name={"tag"}
             placeholder="태그 입력 후, Enter"
-            onChange={(e) => setTag(e.target.value)}
             onKeyDown={onAddTag}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
           />
 
           <div className={styles.tags}>

--- a/front/src/pages/group/setting/GroupSettingPage.tsx
+++ b/front/src/pages/group/setting/GroupSettingPage.tsx
@@ -123,6 +123,7 @@ function GroupSettingPage() {
       if (res.status === 200) {
         refetchGroupMembers();
         showToast({ message: "모임장 위임 성공", type: "success" });
+        navigate(`/group/${groupId}/info`);
       }
     } catch (error) {
       if (isAxiosError<ErrorResponse>(error)) {

--- a/front/src/pages/main/MainPage.tsx
+++ b/front/src/pages/main/MainPage.tsx
@@ -28,6 +28,7 @@ function MainPage() {
   } = useGetGroupsListApi({
     size: 9,
     page: 0,
+    keyword: "",
   });
 
   useLoading(isLoading);
@@ -57,10 +58,10 @@ function MainPage() {
     }
   };
 
-  const onRefetchList = useCallback(() => {
+  const onRefetchList = () => {
     refetchGroupsData();
     refetchMyLikedGroup();
-  }, [refetchGroupsData, refetchMyLikedGroup]);
+  };
 
   return (
     <CommonLayout>
@@ -82,8 +83,8 @@ function MainPage() {
       <SectionTitle title={"내가 찜한 모임"} />
 
       <section className={styles.group_view}>
-        {(myLikedGroups?.content ?? []).map((_item, idx) => (
-          <GroupSearchItem data={_item} key={idx} refetch={onRefetchList} />
+        {(myLikedGroups?.content ?? []).map((_item) => (
+          <GroupSearchItem data={_item} key={_item.id} refetch={onRefetchList} />
         ))}
 
         {
@@ -99,8 +100,8 @@ function MainPage() {
       <SectionTitle title={"추천 모임 표시"} />
 
       <section className={styles.group_view}>
-        {(groupsListData?.content ?? []).map((_item, idx) => (
-          <GroupSearchItem data={_item} key={idx} refetch={onRefetchList} />
+        {(groupsListData?.content ?? []).map((_item) => (
+          <GroupSearchItem data={_item} key={_item.id} refetch={onRefetchList} />
         ))}
       </section>
     </CommonLayout>

--- a/front/src/pages/mypage/profileEdit/ProfileEditPage.tsx
+++ b/front/src/pages/mypage/profileEdit/ProfileEditPage.tsx
@@ -83,7 +83,14 @@ function ProfileEditPage() {
       <form className={styles.form} onSubmit={onSubmit}>
         <Card title="유저 정보">
           {/* 이메일은 수정 불가 → disabled */}
-          <InputField label={"이메일"} required name={"email"} placeholder="example.com" disabled />
+          <InputField
+            label={"이메일"}
+            value={previewUserData?.email ?? ""}
+            required
+            name={"email"}
+            placeholder="example.com"
+            disabled
+          />
 
           <InputField
             label={"닉네임"}

--- a/front/src/pages/privacy/PrivacyPage.module.scss
+++ b/front/src/pages/privacy/PrivacyPage.module.scss
@@ -17,14 +17,16 @@
   padding: 20px;
   max-height: 60vh;
   overflow: auto;
+  margin-bottom: 60px;
 }
 
 .article {
   color: #111827;
-  line-height: 1.7;
+  line-height: 3.2rem;
+  font-size: 1.4rem;
 
   h2 {
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: 800;
     margin-bottom: 12px;
   }

--- a/front/src/pages/privacy/PrivacyPage.tsx
+++ b/front/src/pages/privacy/PrivacyPage.tsx
@@ -19,7 +19,6 @@ function PrivacyPage() {
         <div className={styles.container}>
           <section className={styles.card}>
             <article className={styles.article}>
-              {/* TODO: 실제 개인정보처리방침 전문으로 교체 */}
               <h2>Hobby Hub 개인정보 처리방침</h2>
               <p>
                 Hobby Hub(이하 “회사”)는 「개인정보 보호법」 등 관련 법령을 준수하며, 이용자의

--- a/front/src/shared/components/button/LikeButton.tsx
+++ b/front/src/shared/components/button/LikeButton.tsx
@@ -3,20 +3,17 @@ import { IconButton } from "../icon/IconButton";
 
 type Props = {
   isLike?: boolean;
-  onClick?: () => void;
   size?: number;
 };
 
 /**
  *@description 좋아요 버튼
  */
-function LikeButton({ isLike, onClick, size }: Props) {
-  const [like, setLike] = useState(isLike);
+function LikeButton({ isLike, size }: Props) {
   return (
     <IconButton
-      onClick={() => setLike(!like)}
-      fill={like ? "#f36438" : "#7f838cff"}
-      iconName={like ? "FillHeart" : "StrokeHeart"}
+      fill={isLike ? "#f36438" : "#7f838cff"}
+      iconName={isLike ? "FillHeart" : "StrokeHeart"}
       size={size ?? 14}
     />
   );

--- a/front/src/shared/components/header/Header.tsx
+++ b/front/src/shared/components/header/Header.tsx
@@ -7,6 +7,8 @@ import { IconButton } from "../icon/IconButton";
 import { useEffect, useState } from "react";
 import { usePostLogoutApi } from "@/features/auth/_hooks/mutation";
 import { useUiStore } from "@/shared/stores/ui.store";
+import { useQueryClient } from "@tanstack/react-query";
+import { reactQueryKeys } from "@/shared/constants/reactQueryKeys";
 
 /**
  *@description 헤더 컴포넌트
@@ -19,6 +21,7 @@ export function Header() {
   const { mutateAsync } = usePostLogoutApi();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { showToast } = useUiStore();
+  const queryClient = useQueryClient();
 
   const isMobile = useIsMobile();
 
@@ -51,11 +54,19 @@ export function Header() {
         .then((res) => {
           if (res.status === 200) {
             showToast({ message: "로그아웃되었습니다.", type: "success" });
+            queryClient.removeQueries({
+              queryKey: [reactQueryKeys.user.getUserInfo],
+            });
+
             navigate("/");
             reset(); // 토큰 삭제
           }
         })
         .catch(() => {
+          queryClient.removeQueries({
+            queryKey: [reactQueryKeys.user.getUserInfo],
+          });
+
           showToast({ message: "잘못된 접근입니다.", type: "error" });
           navigate("/");
         });

--- a/front/src/shared/constants/options.ts
+++ b/front/src/shared/constants/options.ts
@@ -10,7 +10,6 @@ export const regionOptions = [
   { label: "세종", value: "세종" },
 ];
 
-// 카테고리 필터 TODO 나중에 api로 대체될 수 있음
 export const categoryOptions = [
   { label: "카테고리", value: "" },
   { label: "개발", value: "develop" },


### PR DESCRIPTION
### 1. 작업
- 유저 프로필 수정 기능 필드 변경
- 태그 중복 입력 이슈 수정
- 멤버 프로필 default 이미지 추가
- 모임 정보 페이지 > 찜기능 추가
- 개인정보처리방침 ui 변경
- 모임장 위임 이벤트 성공 로직 추가
- 로그아웃, refresh token api 수정
- 일정 모임원 리스트 추가